### PR TITLE
feat: add Makefile for automated React hook challenge setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+# List of supported React hooks
+HOOKS := useState useEffect useCallback useMemo useReducer useRef useContext useTransition useDeferredValue
+
+# Declare these as phony targets (i.e., not real files)
+.PHONY: $(HOOKS) empty list
+
+# Copy the appropriate src directory into ./code/src
+$(HOOKS):
+	@echo "Resetting ./code/src and loading challenge for '$@'..."
+	@rm -rf code/src
+	@cp -r chapters/$@/challenge/src code/src
+	@echo "✅ Done. You can now run 'npm start'."
+
+# Clean up the ./code/src folder
+empty:
+	@echo "Removing ./code/src..."
+	@rm -rf code/src
+	@echo "✅ Empty."
+
+# List all valid targets
+list:
+	@echo "Available targets:"
+	@for hook in $(HOOKS); do echo "  make $$hook"; done
+	@echo "  make empty"


### PR DESCRIPTION
This Makefile is designed to streamline the Lunch and Learn workflow.

### Features:
- Run `make useState`, `make useEffect`, etc., to copy the appropriate `challenge/src` into the `code/` directory
- Run `make empty` to clear the `code/src` directory
- Run `make list` to see all available hook targets

This is meant to save time during sessions and reduce setup friction for students. Let me know if you'd like adjustments or additional features! 

Maybe it’s a little extra, but I was bored and wanted to contribute back, thanks for the lunch 'n learns!